### PR TITLE
Fix MIDI recording issue under linux

### DIFF
--- a/python/depinus/__init__.py
+++ b/python/depinus/__init__.py
@@ -8,7 +8,7 @@ from logging.handlers import TimedRotatingFileHandler
 
 def setup_logger():
     logger = logging.getLogger(__name__)  # Logger für das Modul
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
 
     system = platform.system()
 

--- a/python/depinus/__init__.py
+++ b/python/depinus/__init__.py
@@ -8,7 +8,7 @@ from logging.handlers import TimedRotatingFileHandler
 
 def setup_logger():
     logger = logging.getLogger(__name__)  # Logger für das Modul
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
 
     system = platform.system()
 

--- a/python/depinus/midi_interface_observer.py
+++ b/python/depinus/midi_interface_observer.py
@@ -28,13 +28,16 @@ class MidiInterfaceObserver:
     async def _observe(self):
         self._running = True
         while self._running:
+
             output_names = mido.get_output_names()
+            # Filter out virtual RtMidi input client ports from outputs
+            output_names = [name for name in output_names if not name.startswith('RtMidiIn Client:')]
+
             input_names = mido.get_input_names()
             changed = False
             if output_names != self._last_output_interfaces:
                 self._last_output_interfaces = output_names.copy()
                 logger.info('MIDI output interfaces changed: %s', output_names)
-
                 changed = True
             if input_names != self._last_input_interfaces:
                 self._last_input_interfaces = input_names.copy()

--- a/python/depinus/midi_interface_observer.py
+++ b/python/depinus/midi_interface_observer.py
@@ -30,10 +30,12 @@ class MidiInterfaceObserver:
         while self._running:
 
             output_names = mido.get_output_names()
-            # Filter out virtual RtMidi input client ports from outputs
-            output_names = [name for name in output_names if not name.startswith('RtMidiIn Client:')]
-
             input_names = mido.get_input_names()
+
+            # Filter out virtual RtMidi client ports
+            output_names = [name for name in output_names if not name.startswith('RtMidiIn Client:')]
+            input_names = [name for name in input_names if not name.startswith('RtMidiOut Client:')]
+
             changed = False
             if output_names != self._last_output_interfaces:
                 self._last_output_interfaces = output_names.copy()

--- a/python/depinus/piano_player.py
+++ b/python/depinus/piano_player.py
@@ -97,8 +97,11 @@ class PianoPlayer:
         logger.info('Set MIDI out port: %s' % value)
         if (self._midi_output is not None):
             logger.debug('Closing previous MIDI output port...')
-            self._midi_output.close()
-            logger.debug('MIDI output port closed.')
+            try:
+                self._midi_output.close()
+                logger.debug('MIDI output port closed.')
+            except (OSError, IOError) as e:
+                logger.error(f"Failed to close previous MIDI output port: {e}")
         if value:
             try:
                 logger.debug('Opening MIDI output port: %s' % value)

--- a/python/depinus/piano_player.py
+++ b/python/depinus/piano_player.py
@@ -96,10 +96,16 @@ class PianoPlayer:
         '''Sets the MIDI out port.'''
         logger.info('Set MIDI out port: %s' % value)
         if (self._midi_output is not None):
+            logger.debug('Closing previous MIDI output port...')
             self._midi_output.close()
+            logger.debug('MIDI output port closed.')
         if value:
             try:
+                logger.debug('Opening MIDI output port: %s' % value)
                 self._midi_output = mido.open_output(value)
+                logger.debug('Resetting MIDI output...')
+                self._midi_output.reset()
+                logger.debug('MIDI output port opened and reset.')
             except (OSError, IOError) as e:
                 logger.error(f"Failed to open MIDI output port '{value}': {e}")
                 await self.stop()

--- a/python/depinus/piano_player.py
+++ b/python/depinus/piano_player.py
@@ -103,9 +103,10 @@ class PianoPlayer:
             try:
                 logger.debug('Opening MIDI output port: %s' % value)
                 self._midi_output = mido.open_output(value)
-                logger.debug('Resetting MIDI output...')
-                self._midi_output.reset()
-                logger.debug('MIDI output port opened and reset.')
+                #logger.debug('Resetting MIDI output...')
+                #self._midi_output.reset()
+                #logger.debug('MIDI output port opened and reset.')
+                logger.debug('MIDI output port opened.')
             except (OSError, IOError) as e:
                 logger.error(f"Failed to open MIDI output port '{value}': {e}")
                 await self.stop()

--- a/python/depinus/piano_player.py
+++ b/python/depinus/piano_player.py
@@ -103,9 +103,6 @@ class PianoPlayer:
             try:
                 logger.debug('Opening MIDI output port: %s' % value)
                 self._midi_output = mido.open_output(value)
-                #logger.debug('Resetting MIDI output...')
-                #self._midi_output.reset()
-                #logger.debug('MIDI output port opened and reset.')
                 logger.debug('MIDI output port opened.')
             except (OSError, IOError) as e:
                 logger.error(f"Failed to open MIDI output port '{value}': {e}")

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -73,13 +73,13 @@ class PianoRecorder:
         logger.info('Set MIDI input port for recording: %s' % value)
         if self._midi_input is not None:
             try:
-                logger.debug('Removing callback from previous MIDI input port...')
-                self._midi_input.callback = None
+                #logger.debug('Removing callback from previous MIDI input port...')
+                #self._midi_input.callback = None
                 #logger.debug('Resetting previous MIDI input port...')
                 #self._midi_input.reset()
-                #logger.debug('Closing previous MIDI input port...')
-                #self._midi_input.close()
-                #logger.debug('MIDI input port closed.')
+                logger.debug('Closing previous MIDI input port...')
+                self._midi_input.close()
+                logger.debug('MIDI input port closed.')
             except Exception as e:
                 logger.error(f'Failed to close MIDI input port: {e}')
         if value:

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -75,7 +75,9 @@ class PianoRecorder:
             try:
                 logger.debug('Removing callback from previous MIDI input port...')
                 self._midi_input.callback = None
-                logger.debug('Closing previous MIDI input port for recording...')
+                logger.debug('Resetting previous MIDI input port...')
+                self._midi_input.reset()
+                logger.debug('Closing previous MIDI input port...')
                 self._midi_input.close()
                 logger.debug('MIDI input port closed.')
             except Exception as e:

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -72,10 +72,16 @@ class PianoRecorder:
         '''Sets the MIDI input port.'''
         logger.info('Set MIDI input port for recording: %s' % value)
         if self._midi_input is not None:
+            logger.debug('Removing callback from previous MIDI input port...')
+            self._midi_input.callback = None
+            logger.debug('Closing previous MIDI input port for recording...')
             self._midi_input.close()
+            logger.debug('MIDI input port closed.')
         if value:
             try:
+                logger.debug('Opening MIDI input port for recording: %s' % value)
                 self._midi_input = mido.open_input(value, callback=self._on_midi_input_message)
+                logger.debug('MIDI input port opened.')
             except (OSError, IOError) as e:
                 logger.error(f"Failed to open MIDI input port '{value}': {e}")
                 self._midi_input = None

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -73,10 +73,6 @@ class PianoRecorder:
         logger.info('Set MIDI input port for recording: %s' % value)
         if self._midi_input is not None:
             try:
-                #logger.debug('Removing callback from previous MIDI input port...')
-                #self._midi_input.callback = None
-                #logger.debug('Resetting previous MIDI input port...')
-                #self._midi_input.reset()
                 logger.debug('Closing previous MIDI input port...')
                 self._midi_input.close()
                 logger.debug('MIDI input port closed.')

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -75,11 +75,11 @@ class PianoRecorder:
             try:
                 logger.debug('Removing callback from previous MIDI input port...')
                 self._midi_input.callback = None
-                logger.debug('Resetting previous MIDI input port...')
-                self._midi_input.reset()
-                logger.debug('Closing previous MIDI input port...')
-                self._midi_input.close()
-                logger.debug('MIDI input port closed.')
+                #logger.debug('Resetting previous MIDI input port...')
+                #self._midi_input.reset()
+                #logger.debug('Closing previous MIDI input port...')
+                #self._midi_input.close()
+                #logger.debug('MIDI input port closed.')
             except Exception as e:
                 logger.error(f'Failed to close MIDI input port: {e}')
         if value:

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -72,11 +72,14 @@ class PianoRecorder:
         '''Sets the MIDI input port.'''
         logger.info('Set MIDI input port for recording: %s' % value)
         if self._midi_input is not None:
-            logger.debug('Removing callback from previous MIDI input port...')
-            self._midi_input.callback = None
-            logger.debug('Closing previous MIDI input port for recording...')
-            self._midi_input.close()
-            logger.debug('MIDI input port closed.')
+            try:
+                logger.debug('Removing callback from previous MIDI input port...')
+                self._midi_input.callback = None
+                logger.debug('Closing previous MIDI input port for recording...')
+                self._midi_input.close()
+                logger.debug('MIDI input port closed.')
+            except Exception as e:
+                logger.error(f'Failed to close MIDI input port: {e}')
         if value:
             try:
                 logger.debug('Opening MIDI input port for recording: %s' % value)


### PR DESCRIPTION
This PR fixes a recording issue that occurs in Linux only.

Linux uses the ALSA Backend and creates virtual RtMidi client ports. The midi_interface_observer runs into an endless loop and detects a new port which is opened and which creates another virtual port and so on. The fix is to suppress all RtMidi client ports.

