### PR TITLE
Reset usb midi port bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,15 @@ If you wish to run the frontend server on port 80, the procedure depends on your
 
 ### Recording on Linux
 
-On Linux systems using ALSA with USB MIDI devices, MIDI recording may experience strange timing issues. This is probably caused by a kernel-level state corruption in ALSA's bidirectional MIDI port handling, where the playback operation leaves the MIDI device in an inconsistent state.
+On Linux systems using ALSA with USB MIDI devices, MIDI recording may experience strange timing issues. This is probably caused by a kernel-level state corruption in ALSA's bidirectional MIDI port handling, where the startup procedure leaves the MIDI device in an inconsistent state.
 
 **Symptoms:**
 - MIDI events arrive with significant delays (100-400ms)
 - Recording timing is accurate again after plugging off/in the MIDI USB device
-- Problem reoccurs after playing MIDI files
 
 **Workaround:**
 
-DEPINUS includes an optional USB MIDI Reset Daemon that automatically resets the USB MIDI device before each recording session. To enable this feature:
+DEPINUS includes an optional USB MIDI Reset Daemon that automatically resets the USB MIDI device once at startup to ensure a clean ALSA state. To enable this feature:
 
 1. Navigate to the resources folder in your DEPINUS installation
 2. Run the following command with administrator privileges:
@@ -78,7 +77,7 @@ DEPINUS includes an optional USB MIDI Reset Daemon that automatically resets the
    sudo ./midi_usb_reset enable
    ```
 
-The daemon will now start automatically on each system boot and reset the USB MIDI device before each recording, ensuring accurate timing.
+The daemon will now start automatically on each system boot. DEPINUS triggers a single reset shortly after startup, ensuring accurate timing for all subsequent playback and recording sessions.
 
 To disable the daemon:
 

--- a/python/depinus/piano_daemon.py
+++ b/python/depinus/piano_daemon.py
@@ -91,7 +91,6 @@ class PianoDaemon:
             self._piano_player.register_for_play_end(self._on_play_end)
 
             self._piano_recorder.register_for_recording_end(self._on_recording_end)
-            self._piano_recorder.register_for_waiting_state(self._on_recording_waiting_state)
             self._piano_recorder.register_for_midi_messages(self._on_recording_midi_message)
             self._piano_recorder.register_for_live_midi_messages(self._on_live_midi_message)
 
@@ -503,19 +502,6 @@ class PianoDaemon:
         '''Callback for live MIDI input messages - forwards to UI for keyboard visualization.'''
         await self._websocket_server.send_keyboard_message(mido_message)
 
-
-    async def _on_recording_waiting_state(self, is_waiting):
-        '''Callback when recording preparation state changes.'''
-        await self._websocket_server.send_info_message({
-            'infoType': 'playState',
-            'isWaiting': is_waiting
-        })
-        # On Linux the USB reset invalidates the MIDI output handle in PianoPlayer.
-        # The MidiInterfaceObserver may not detect the brief disconnect (5s interval),
-        # so we proactively reopen the output port once the reset is complete.
-        if not is_waiting and platform.system() != 'Windows' and self._midi_out_ports_selected:
-            logger.debug('Reopening MIDI output port after USB reset...')
-            await self._piano_player.set_midi_out_port(self._midi_out_ports_selected)
 
     async def _on_recording_midi_message(self, midi_event_base64):
         '''Callback for MIDI messages during recording - send raw MIDI bytes (base64).'''

--- a/python/depinus/piano_daemon.py
+++ b/python/depinus/piano_daemon.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import mido
 import io
+import platform
 import requests
 
 from depinus import logger
@@ -94,6 +95,11 @@ class PianoDaemon:
             self._piano_recorder.register_for_midi_messages(self._on_recording_midi_message)
             self._piano_recorder.register_for_live_midi_messages(self._on_live_midi_message)
 
+            # Trigger a startup USB MIDI reset (Linux only) after the observer has had time
+            # to detect the initial MIDI ports. This ensures a clean ALSA state from the
+            # beginning, fixing timing issues (e.g. delayed circle-of-fifths display).
+            self._background_tasks.add(asyncio.create_task(self._perform_startup_reset()))
+
             logger.info('Entering main loop...')
             self._mainloop = asyncio.Future()
             await self._mainloop
@@ -102,6 +108,32 @@ class PianoDaemon:
 
         except Exception:
             logger.exception("Piano daemon aborted unexpectedly.")
+
+
+    async def _perform_startup_reset(self):
+        '''Performs a USB MIDI reset at startup (Linux only).
+        Waits for the MidiInterfaceObserver to complete its first port detection
+        before triggering the reset, then reopens both MIDI in and out ports.
+        '''
+        if platform.system() == 'Windows':
+            return
+
+        # Give the MidiInterfaceObserver time to do its first poll and set up ports
+        logger.debug('Startup reset: waiting for initial MIDI port detection...')
+        await asyncio.sleep(2.0)
+
+        if not self._midi_in_ports_selected:
+            logger.debug('Startup reset: no MIDI input port available, skipping')
+            return
+
+        await self._piano_recorder.perform_startup_reset()
+
+        # Reopen the output port so the player has a fresh handle after the reset
+        if self._midi_out_ports_selected:
+            logger.debug('Startup reset: reopening MIDI output port...')
+            await self._piano_player.set_midi_out_port(self._midi_out_ports_selected)
+
+        logger.info('Startup USB MIDI reset complete - MIDI interfaces ready.')
 
 
     async def _on_control_command(self, cmd):
@@ -478,6 +510,12 @@ class PianoDaemon:
             'infoType': 'playState',
             'isWaiting': is_waiting
         })
+        # On Linux the USB reset invalidates the MIDI output handle in PianoPlayer.
+        # The MidiInterfaceObserver may not detect the brief disconnect (5s interval),
+        # so we proactively reopen the output port once the reset is complete.
+        if not is_waiting and platform.system() != 'Windows' and self._midi_out_ports_selected:
+            logger.debug('Reopening MIDI output port after USB reset...')
+            await self._piano_player.set_midi_out_port(self._midi_out_ports_selected)
 
     async def _on_recording_midi_message(self, midi_event_base64):
         '''Callback for MIDI messages during recording - send raw MIDI bytes (base64).'''

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -34,7 +34,6 @@ class PianoRecorder:
         self._pause_start_time = None
         self._total_pause_duration = 0
         self._recording_callbacks = set()
-        self._waiting_callbacks = set()
         self._midi_message_callbacks = set()
         self._live_midi_callbacks = set()
         self._tempo = 1.0
@@ -122,14 +121,6 @@ class PianoRecorder:
         '''
         self._recording_callbacks.add(callback)
 
-    def register_for_waiting_state(self, callback):
-        '''Subscribe for notifications about waiting state changes
-
-            Parameters:
-            callback: Async callback routine to be invoked with is_waiting (bool)
-        '''
-        self._waiting_callbacks.add(callback)
-
     def register_for_midi_messages(self, callback):
         '''Subscribe for notifications about MIDI messages during recording
 
@@ -162,71 +153,6 @@ class PianoRecorder:
             logger.debug('USB reset daemon not available (expected on Windows or when disabled)')
         except Exception as e:
             logger.error(f'Error triggering USB reset: {e}')
-
-    async def _wait_for_usb_reset_complete(self, saved_port_name):
-        '''Waits for USB reset to complete by monitoring port disappearance and reappearance.
-        
-        Parameters:
-            saved_port_name: The MIDI port name before reset
-            
-        Returns:
-            True if reset completed successfully or no reset needed, False on error
-        '''
-        # Skip USB reset on Windows - not needed there
-        if platform.system() == 'Windows':
-            logger.debug('Windows detected - skipping USB reset (not required)')
-            return True
-        
-        # Notify about waiting state
-        for callback in self._waiting_callbacks:
-            await callback(True)
-        
-        # Trigger USB reset before recording to ensure clean ALSA state
-        self._trigger_usb_reset()
-
-        # Wait for USB device to disappear and come back after reset (on Linux)
-        # Phase 1: Wait for device to disappear (MidiInterfaceObserver sets port to None)
-        logger.info(f'Waiting for USB MIDI device "{saved_port_name}" to disappear after reset...')
-        max_wait_disappear = 2  # Maximum 2 seconds to disappear
-        wait_increment = 0.1
-        waited = 0
-        while waited < max_wait_disappear:
-            await asyncio.sleep(wait_increment)
-            waited += wait_increment
-            if self._midi_in_port is None:
-                logger.info(f'USB MIDI device disappeared after {waited:.1f}s')
-                break
-        else:
-            # Device didn't disappear - probably no daemon running (Windows)
-            # or device enumeration was very fast
-            logger.debug(f'USB MIDI device did not disappear (no reset or very fast re-enumeration)')
-            # Small delay to ensure any pending reset is complete
-            await asyncio.sleep(0.2)
-            if self._midi_in_port == saved_port_name:
-                logger.info('Port still available, proceeding with recording')
-                return True
-            else:
-                logger.error('MIDI input port changed unexpectedly')
-                return False
-        
-        # Phase 2: Wait for device to come back (only if it disappeared)
-        if self._midi_in_port is None:
-            logger.info(f'Waiting for USB MIDI device to re-enumerate...')
-            max_wait_reappear = 8  # Maximum 8 seconds to reappear
-            waited = 0
-            while waited < max_wait_reappear:
-                await asyncio.sleep(wait_increment)
-                waited += wait_increment
-                if self._midi_in_port == saved_port_name:
-                    logger.info(f'USB MIDI device re-enumerated and port restored after {waited:.1f}s')
-                    return True
-            
-            # Device did not come back in time
-            logger.error(f'MIDI input port "{saved_port_name}" did not re-enumerate after {max_wait_reappear}s')
-            return False
-        
-        # Device didn't disappear, no reset needed
-        return True
 
     async def perform_startup_reset(self):
         '''Triggers a USB MIDI reset at startup (Linux only) to ensure clean ALSA state from
@@ -318,23 +244,6 @@ class PianoRecorder:
         if not self._midi_in_port:
             logger.error('No MIDI input port selected for recording')
             return
-
-        # NOTE: Pre-recording USB reset is currently disabled for testing.
-        # Only the startup reset (in PianoDaemon._perform_startup_reset) is active.
-        # Re-enable this block if timing issues reoccur after playback.
-        #
-        # saved_port_name = self._midi_in_port
-        # if not await self._wait_for_usb_reset_complete(saved_port_name):
-        #     for callback in self._waiting_callbacks:
-        #         await callback(False)
-        #     return
-        # for callback in self._waiting_callbacks:
-        #     await callback(False)
-        # if platform.system() != 'Windows':
-        #     await self._reopen_midi_port()
-        #     if self._midi_input is None:
-        #         logger.error('Failed to reopen MIDI port after USB reset - aborting recording')
-        #         return
 
         logger.info('Start recording MIDI messages')
         self._recording = True

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -139,7 +139,12 @@ class PianoRecorder:
         self._live_midi_callbacks.add(callback)
 
     def _trigger_usb_reset(self):
-        '''Triggers the USB MIDI reset daemon (Linux only, silently ignored on Windows).'''
+        '''Triggers the USB MIDI reset daemon (Linux only).
+        
+        Returns:
+            True if the reset was successfully sent to the daemon, False if the daemon
+            is not available (not installed or disabled).
+        '''
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(1.0)
@@ -148,11 +153,14 @@ class PianoRecorder:
             sock.shutdown(socket.SHUT_WR)  # Signal end of send, allow server to read
             sock.close()
             logger.info('USB MIDI reset triggered successfully')
+            return True
         except (ConnectionRefusedError, TimeoutError, OSError):
             # Daemon not running (Windows or disabled on Linux) - this is OK
             logger.debug('USB reset daemon not available (expected on Windows or when disabled)')
+            return False
         except Exception as e:
             logger.error(f'Error triggering USB reset: {e}')
+            return False
 
     async def perform_startup_reset(self):
         '''Triggers a USB MIDI reset at startup (Linux only) to ensure clean ALSA state from
@@ -168,7 +176,9 @@ class PianoRecorder:
 
         logger.info('Performing startup USB MIDI reset...')
         saved_port_name = self._midi_in_port
-        self._trigger_usb_reset()
+        if not self._trigger_usb_reset():
+            logger.debug('Startup reset: daemon not available, skipping')
+            return
 
         # Phase 1: Wait for device to disappear
         max_wait_disappear = 2

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -228,6 +228,55 @@ class PianoRecorder:
         # Device didn't disappear, no reset needed
         return True
 
+    async def perform_startup_reset(self):
+        '''Triggers a USB MIDI reset at startup (Linux only) to ensure clean ALSA state from
+        the beginning. Unlike the pre-recording reset, this runs silently without waiting
+        state callbacks.
+        '''
+        if platform.system() == 'Windows':
+            return
+
+        if not self._midi_in_port:
+            logger.debug('Startup reset: no MIDI input port configured, skipping')
+            return
+
+        logger.info('Performing startup USB MIDI reset...')
+        saved_port_name = self._midi_in_port
+        self._trigger_usb_reset()
+
+        # Phase 1: Wait for device to disappear
+        max_wait_disappear = 2
+        wait_increment = 0.1
+        waited = 0
+        while waited < max_wait_disappear:
+            await asyncio.sleep(wait_increment)
+            waited += wait_increment
+            if self._midi_in_port is None:
+                logger.info(f'Startup reset: USB MIDI device disappeared after {waited:.1f}s')
+                break
+        else:
+            logger.debug('Startup reset: device did not disappear (daemon not running?)')
+            await asyncio.sleep(0.2)
+            await self._reopen_midi_port()
+            return
+
+        # Phase 2: Wait for device to come back
+        if self._midi_in_port is None:
+            max_wait_reappear = 8
+            waited = 0
+            while waited < max_wait_reappear:
+                await asyncio.sleep(wait_increment)
+                waited += wait_increment
+                if self._midi_in_port == saved_port_name:
+                    logger.info(f'Startup reset: USB MIDI device re-enumerated after {waited:.1f}s')
+                    break
+            else:
+                logger.error(f'Startup reset: port "{saved_port_name}" did not re-enumerate after {max_wait_reappear}s')
+                return
+
+        await self._reopen_midi_port()
+        logger.info('Startup USB MIDI reset complete.')
+
     async def _reopen_midi_port(self):
         '''Closes and reopens the MIDI input port and restarts the monitor task.
         Used after USB reset to ensure a fresh, valid port handle.
@@ -270,29 +319,22 @@ class PianoRecorder:
             logger.error('No MIDI input port selected for recording')
             return
 
-        # Save the port name before USB reset (it will be cleared during reset)
-        saved_port_name = self._midi_in_port
-
-        # Wait for USB reset to complete
-        if not await self._wait_for_usb_reset_complete(saved_port_name):
-            # Notify about waiting state ending
-            for callback in self._waiting_callbacks:
-                await callback(False)
-            return
-
-        # Notify about waiting state ending
-        for callback in self._waiting_callbacks:
-            await callback(False)
-
-        # On Linux: After USB reset, always reopen the MIDI port to get a fresh handle.
-        # The persistent _monitor_task may have crashed or may hold a stale handle from
-        # the disconnected device. The observer (5s interval) may not have updated it yet.
-        if platform.system() != 'Windows':
-            logger.debug('Reopening MIDI port after USB reset to ensure fresh handle...')
-            await self._reopen_midi_port()
-            if self._midi_input is None:
-                logger.error('Failed to reopen MIDI port after USB reset - aborting recording')
-                return
+        # NOTE: Pre-recording USB reset is currently disabled for testing.
+        # Only the startup reset (in PianoDaemon._perform_startup_reset) is active.
+        # Re-enable this block if timing issues reoccur after playback.
+        #
+        # saved_port_name = self._midi_in_port
+        # if not await self._wait_for_usb_reset_complete(saved_port_name):
+        #     for callback in self._waiting_callbacks:
+        #         await callback(False)
+        #     return
+        # for callback in self._waiting_callbacks:
+        #     await callback(False)
+        # if platform.system() != 'Windows':
+        #     await self._reopen_midi_port()
+        #     if self._midi_input is None:
+        #         logger.error('Failed to reopen MIDI port after USB reset - aborting recording')
+        #         return
 
         logger.info('Start recording MIDI messages')
         self._recording = True

--- a/python/depinus/piano_recorder.py
+++ b/python/depinus/piano_recorder.py
@@ -180,35 +180,36 @@ class PianoRecorder:
             logger.debug('Startup reset: daemon not available, skipping')
             return
 
-        # Phase 1: Wait for device to disappear
-        max_wait_disappear = 2
-        wait_increment = 0.1
+        # Poll mido.get_input_names() directly - do NOT rely on self._midi_in_port, which
+        # is only updated by the MidiInterfaceObserver every 5 seconds and would never
+        # change within the short wait windows below.
+
+        # Phase 1: Wait for device to disappear from the OS (up to 6s)
+        max_wait_disappear = 6
+        wait_increment = 0.2
         waited = 0
         while waited < max_wait_disappear:
             await asyncio.sleep(wait_increment)
             waited += wait_increment
-            if self._midi_in_port is None:
+            if saved_port_name not in mido.get_input_names():
                 logger.info(f'Startup reset: USB MIDI device disappeared after {waited:.1f}s')
                 break
         else:
-            logger.debug('Startup reset: device did not disappear (daemon not running?)')
-            await asyncio.sleep(0.2)
-            await self._reopen_midi_port()
+            logger.debug('Startup reset: device did not disappear within timeout')
             return
 
-        # Phase 2: Wait for device to come back
-        if self._midi_in_port is None:
-            max_wait_reappear = 8
-            waited = 0
-            while waited < max_wait_reappear:
-                await asyncio.sleep(wait_increment)
-                waited += wait_increment
-                if self._midi_in_port == saved_port_name:
-                    logger.info(f'Startup reset: USB MIDI device re-enumerated after {waited:.1f}s')
-                    break
-            else:
-                logger.error(f'Startup reset: port "{saved_port_name}" did not re-enumerate after {max_wait_reappear}s')
-                return
+        # Phase 2: Wait for device to re-enumerate (up to 10s)
+        max_wait_reappear = 10
+        waited = 0
+        while waited < max_wait_reappear:
+            await asyncio.sleep(wait_increment)
+            waited += wait_increment
+            if saved_port_name in mido.get_input_names():
+                logger.info(f'Startup reset: USB MIDI device re-enumerated after {waited:.1f}s')
+                break
+        else:
+            logger.error(f'Startup reset: port "{saved_port_name}" did not re-enumerate after {max_wait_reappear}s')
+            return
 
         await self._reopen_midi_port()
         logger.info('Startup USB MIDI reset complete.')


### PR DESCRIPTION
This PR fixes the broken ALSA MIDI workaround.
The workaround did not work any many after the websocket redesign.
The new solution solution triggers a single MIDI USB reset at Depinus startup.